### PR TITLE
Add items from NAACL to now

### DIFF
--- a/nmlp.bib
+++ b/nmlp.bib
@@ -1,3 +1,182 @@
+@inproceedings{zhu-etal-2025-meaning,
+    title = "Meaning Beyond Truth Conditions: Evaluating Discourse Level Understanding via Anaphora Accessibility",
+    author = "Zhu, Xiaomeng  and
+      Zhou, Zhenghao  and
+      Charlow, Simon  and
+      Frank, Robert",
+    editor = "Che, Wanxiang  and
+      Nabende, Joyce  and
+      Shutova, Ekaterina  and
+      Pilehvar, Mohammad Taher",
+    booktitle = "Proceedings of the 63rd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = jul,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.acl-long.432/",
+    doi = "10.18653/v1/2025.acl-long.432",
+    pages = "8824--8842",
+    ISBN = "979-8-89176-251-0",
+    abstract = "We present a hierarchy of natural language understanding abilities and argue for the importance of moving beyond assessments of understanding at the lexical and sentence levels to the discourse level. We propose the task of anaphora accessibility as a diagnostic for assessing discourse understanding, and to this end, present an evaluation dataset inspired by theoretical research in dynamic semantics. We evaluate human and LLM performance on our dataset and find that LLMs and humans align on some tasks and diverge on others. Such divergence can be explained by LLMs' reliance on specific lexical items during language comprehension, in contrast to human sensitivity to structural abstractions."
+}
+@inproceedings{hou-2020-bridging,
+    title = "Bridging Anaphora Resolution as Question Answering",
+    author = "Hou, Yufang",
+    editor = "Jurafsky, Dan  and
+      Chai, Joyce  and
+      Schluter, Natalie  and
+      Tetreault, Joel",
+    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
+    month = jul,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2020.acl-main.132/",
+    url_arxiv = "https://arxiv.org/abs/2004.07898"
+    doi = "10.18653/v1/2020.acl-main.132",
+    pages = "1428--1438",
+    abstract = "Most previous studies on bridging anaphora resolution (Poesio et al., 2004; Hou et al., 2013b; Hou, 2018a) use the pairwise model to tackle the problem and assume that the gold mention information is given. In this paper, we cast bridging anaphora resolution as question answering based on context. This allows us to find the antecedent for a given anaphor without knowing any gold mention information (except the anaphor itself). We present a question answering framework (BARQA) for this task, which leverages the power of transfer learning. Furthermore, we propose a novel method to generate a large amount of ``quasi-bridging'' training data. We show that our model pre-trained on this dataset and fine-tuned on a small amount of in-domain dataset achieves new state-of-the-art results for bridging anaphora resolution on two bridging corpora (ISNotes (Markert et al., 2012) and BASHI (Ro {\ensuremath{\ddot{}}}siger, 2018))."
+}
+@inproceedings{he-etal-2025-xcomps,
+    title = "{XCOMPS}: A Multilingual Benchmark of Conceptual Minimal Pairs",
+    author = "He, Linyang  and
+      Nie, Ercong  and
+      Dindar, Sukru Samet  and
+      Firoozi, Arsalan  and
+      Nguyen, Van  and
+      Puffay, Corentin  and
+      Shimizu, Riki  and
+      Ye, Haotian  and
+      Brennan, Jonathan  and
+      Schmid, Helmut  and
+      Schütze, Hinrich  and
+      Mesgarani, Nima",
+    editor = "Hahn, Michael  and
+      Rani, Priya  and
+      Kumar, Ritesh  and
+      Shcherbakov, Andreas  and
+      Sorokin, Alexey  and
+      Serikov, Oleg  and
+      Cotterell, Ryan  and
+      Vylomova, Ekaterina",
+    booktitle = "Proceedings of the 7th Workshop on Research in Computational Linguistic Typology and Multilingual NLP",
+    month = aug,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.sigtyp-1.9/",
+    doi = "10.18653/v1/2025.sigtyp-1.9",
+    pages = "75--81",
+    ISBN = "979-8-89176-281-7",
+    abstract = "In this work, we introduce XCOMPS, a multilingual conceptual minimal pair dataset that covers 17 languages.Using this dataset, we evaluate LLMs' multilingual conceptual understanding through metalinguistic prompting, direct probability measurement, and neurolinguistic probing. We find that: 1) LLMs exhibit weaker conceptual understanding for low-resource languages, and accuracy varies across languages despite being tested on the same concept sets. 2) LLMs excel at distinguishing concept-property pairs that are visibly different but exhibit a marked performance drop when negative pairs share subtle semantic similarities. 3) More morphologically complex languages yield lower concept understanding scores and require deeper layers for conceptual reasoning."
+}
+
+@misc{liu2025goldmedalsroomdiagnosing,
+      title={The Gold Medals in an Empty Room: Diagnosing Metalinguistic Reasoning in LLMs with Camlang},
+      author={Fenghua Liu and Yulong Chen and Yixuan Liu and Zhujun Jin and Solomon Tsai and Ming Zhong},
+      year={2025},
+      eprint={2509.00425},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2509.00425},
+}
+
+@inproceedings{ginn-palmer-2025-llm,
+    title = "{LLM} Dependency Parsing with In-Context Rules",
+    author = "Ginn, Michael  and
+      Palmer, Alexis",
+    editor = "Fei, Hao  and
+      Tu, Kewei  and
+      Zhang, Yuhui  and
+      Hu, Xiang  and
+      Han, Wenjuan  and
+      Jia, Zixia  and
+      Zheng, Zilong  and
+      Cao, Yixin  and
+      Zhang, Meishan  and
+      Lu, Wei  and
+      Siddharth, N.  and
+      {\O}vrelid, Lilja  and
+      Xue, Nianwen  and
+      Zhang, Yue",
+    booktitle = "Proceedings of the 1st Joint Workshop on Large Language Models and Structure Modeling (XLLM 2025)",
+    month = aug,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.xllm-1.17/",
+    doi = "10.18653/v1/2025.xllm-1.17",
+    pages = "186--196",
+    ISBN = "979-8-89176-286-2",
+    abstract = "We study whether incorporating rules (in various formats) can aid large language models to perform dependency parsing. We consider a paradigm in which LLMs first produce symbolic rules given fully labeled examples, and the rules are then provided in a subsequent call that performs the actual parsing. In addition, we experiment with providing human-created annotation guidelines in-context to the LLMs. We test on eight low-resource languages from Universal Dependencies, finding that while both methods for rule incorporation improve zero-shot performance, the benefit disappears with a few labeled in-context examples."
+}
+
+@inproceedings{pedrotti-etal-2025-humans,
+    title = "How Humans and {LLM}s Organize Conceptual Knowledge: Exploring Subordinate Categories in {I}talian",
+    author = "Pedrotti, Andrea  and
+      Rambelli, Giulia  and
+      Villani, Caterina  and
+      Bolognesi, Marianna",
+    editor = "Che, Wanxiang  and
+      Nabende, Joyce  and
+      Shutova, Ekaterina  and
+      Pilehvar, Mohammad Taher",
+    booktitle = "Proceedings of the 63rd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = jul,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.acl-long.224/",
+    doi = "10.18653/v1/2025.acl-long.224",
+    pages = "4464--4482",
+    ISBN = "979-8-89176-251-0",
+    abstract = "People can categorize the same entity at multiple taxonomic levels, such as basic (bear), superordinate (animal), and subordinate (grizzly bear). While prior research has focused on basic-level categories, this study is the first attempt to examine the organization of categories by analyzing exemplars produced at the subordinate level. We present a new Italian psycholinguistic dataset of human-generated exemplars for 187 concrete words. We then leverage these data to evaluate whether textual and vision LLMs produce meaningful exemplars that align with human category organization across three key tasks: exemplar generation, category induction, and typicality judgment. Our findings show a low alignment between humans and LLMs, consistent with previous studies. However, their performance varies notably across different semantic domains. Ultimately, this study highlights both the promises and the constraints of using AI-generated exemplars to support psychological and linguistic research."
+}
+
+@inproceedings{zhang-etal-2025-read,
+    title = "Read it in Two Steps: Translating Extremely Low-Resource Languages with Code-Augmented Grammar Books",
+    author = "Zhang, Chen  and
+      Lin, Jiuheng  and
+      Liu, Xiao  and
+      Zhang, Zekai  and
+      Feng, Yansong",
+    editor = "Che, Wanxiang  and
+      Nabende, Joyce  and
+      Shutova, Ekaterina  and
+      Pilehvar, Mohammad Taher",
+    booktitle = "Proceedings of the 63rd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)",
+    month = jul,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.acl-long.202/",
+    doi = "10.18653/v1/2025.acl-long.202",
+    pages = "3977--3997",
+    ISBN = "979-8-89176-251-0",
+    abstract = "While large language models (LLMs) have shown promise in translating extremely low-resource languages using resources like dictionaries, the effectiveness of grammar books remains debated. This paper investigates the role of grammar books in translating extremely low-resource languages by decomposing it into two key steps: grammar rule retrieval and application. To facilitate the study, we introduce ZhuangRules, a modularized dataset of grammar rules and their corresponding test sentences. Our analysis reveals that rule retrieval constitutes a primary bottleneck in grammar-based translation. Moreover, although LLMs can apply simple rules for translation when explicitly provided, they encounter difficulties in handling more complex rules. To address these challenges, we propose representing grammar rules as code functions, considering their similarities in structure and the benefit of code in facilitating LLM reasoning. Our experiments show that using code rules significantly boosts both rule retrieval and application, ultimately resulting in a 13.1{\%} BLEU improvement in translation."
+}
+
+@inproceedings{cheng-amiri-2025-linguistic,
+    title = "Linguistic Blind Spots of Large Language Models",
+    author = "Cheng, Jiali  and
+      Amiri, Hadi",
+    editor = "Kuribayashi, Tatsuki  and
+      Rambelli, Giulia  and
+      Takmaz, Ece  and
+      Wicke, Philipp  and
+      Li, Jixing  and
+      Oh, Byung-Doh",
+    booktitle = "Proceedings of the Workshop on Cognitive Modeling and Computational Linguistics",
+    month = may,
+    year = "2025",
+    address = "Albuquerque, New Mexico, USA",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.cmcl-1.3/",
+    doi = "10.18653/v1/2025.cmcl-1.3",
+    pages = "1--17",
+    ISBN = "979-8-89176-227-5",
+    abstract = "Large language models (LLMs) serve as the foundation of numerous AI applications today. However, despite their remarkable proficiency in generating coherent text, questions linger regarding their ability in performing fine-grained linguistic annotation tasks, such as detecting nouns or verbs, or identifying more complex syntactic structures like clauses or T-units in input texts. These tasks require precise syntactic and semantic understanding of input text, and when LLMs underperform on specific linguistic structures, it raises concerns about their reliability for detailed linguistic analysis and whether their (even correct) outputs truly reflect an understanding of the inputs. In this paper, we empirically study recent LLMs performance across fine-grained linguistic annotation tasks. Through a series of experiments, we find that recent LLMs show limited efficacy in addressing linguistic queries and often struggle with linguistically complex inputs. We show that the most capable LLM (Llama3-70b) makes notable errors in detecting linguistic structures, such as misidentifying embedded clauses, failing to recognize verb phrases, and confusing complex nominals with clauses. Our study provides valuable insights to inform future endeavors in LLM design and development."
+}
 
 @inproceedings{wilson-13,
 	title = {Toward automatic processing of {E}nglish metalanguage},


### PR DESCRIPTION
Resolves #2 #3 & #5 

For ref:
Quick organizing jots based on #4  
liu2025goldmedalsroomdiagnosing - "knowledge encoded as NML"
ginn-palmer-2025-llm - "knowledge encoded as NML/SML"
pedrotti-etal-2025-humans - "prompting an LLM with NML questions/options"
zhang-etal-2025-read : "knowledge encoded as NML/SML"
cheng-amiri-2025-linguistic: "prompting an LLM with NML questions/options"
he-etal-2025-xcomp: "prompting an LLM with NML questions/options"